### PR TITLE
Use stable nixpkgs url

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -2,7 +2,7 @@
   description = "Basic nix conf";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-24.11-darwin";
     nix-darwin.url = "github:LnL7/nix-darwin";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
   };


### PR DESCRIPTION
### Description

While exploring home-manager, determined that using a stable version of nixpkgs would be better than using unstable. I don't want to have to deal with [minor bugs](https://www.reddit.com/r/NixOS/comments/1f46b04/whats_the_difference_between_these_nixosunstable/) that might occur for unstable. The nix-darwin docs recommends using stable as well in its [example](https://github.com/LnL7/nix-darwin?tab=readme-ov-file#step-1-creating-flakenix). This would also also allowing using a stable home-manager version that has been tested against the nixpkgs version.