### PR TITLE
Setup core.nix

### DIFF
--- a/home/core.nix
+++ b/home/core.nix
@@ -1,0 +1,13 @@
+{pkgs, ...}: {
+  home.packages = with pkgs; [
+    git
+  ];
+
+  programs = {
+    neovim = {
+      enable = true;
+      defaultEditor = true;
+      vimAlias = true;
+    };
+  };
+}

--- a/home/default.nix
+++ b/home/default.nix
@@ -4,25 +4,15 @@
   homedir,
   ...
 }: {
-  # Home Manager needs a bit of information about you and the
-  # paths it should manage.
-  home.username = username;
-  home.homeDirectory = homedir;
-
-  home.packages = with pkgs; [
-    git
+  imports = [
+    ./core.nix
   ];
 
-  # This value determines the Home Manager release that your
-  # configuration is compatible with. This helps avoid breakage
-  # when a new Home Manager release introduces backwards
-  # incompatible changes.
-  #
-  # You can update Home Manager without changing this value. See
-  # the Home Manager release notes for a list of state version
-  # changes in each release.
-  home.stateVersion = "24.11";
+  home = {
+    username = username;
+    homeDirectory = homedir;
+    stateVersion = "24.11";
+  };
 
-  # Let Home Manager install and manage itself.
   programs.home-manager.enable = true;
 }


### PR DESCRIPTION
## Description

Create home/core.nix
- creates a home/core.nix for core home manager packages and programs

Update home/default.nix
- Updates home/default.nix to import home/core.nix and changes home to an attribute set rather than individual settings
- Removed comments and cleaned up home attribute set

## Checklist
- [x] Tested changes on macos VM?
