### PR TITLE
Setup home/shell.nix

### DIFF
--- a/home/core.nix
+++ b/home/core.nix
@@ -1,6 +1,9 @@
 {pkgs, ...}: {
   home.packages = with pkgs; [
     cowsay
+    fzf
+    zsh-fzf-history-search
+    zsh-fzf-tab
   ];
 
   programs = {

--- a/home/default.nix
+++ b/home/default.nix
@@ -7,6 +7,7 @@
   imports = [
     ./core.nix
     ./git.nix
+    ./shell.nix
   ];
 
   home = {

--- a/home/shell.nix
+++ b/home/shell.nix
@@ -1,0 +1,21 @@
+{pkgs, ...}: {
+  programs.zsh = {
+    enable = true;
+    syntaxHighlighting.enable = true;
+    autocd = true;
+    autosuggestion.enable = true;
+
+    history = {
+      ignoreAllDups = true;
+      ignoreSpace = true;
+    };
+
+    initExtra = ''
+      setopt hist_find_no_dups
+      setopt hist_save_no_dups
+
+      source ${pkgs.zsh-fzf-history-search}/share/zsh-fzf-history-search/zsh-fzf-history-search.plugin.zsh
+      source ${pkgs.zsh-fzf-tab}/share/fzf-tab/fzf-tab.plugin.zsh
+    '';
+  };
+}


### PR DESCRIPTION
## Description

Setup home/shell.nix
- Creates home/shell.nix for zsh configuration
- Enables zsh settings and plugins

home/core.nix
- Adds fzf, zsh-fzf-history-search and zsh-fzf-tab

## Checklist
- [x] Tested changes on macos VM?
