### PR TITLE
Update configuration to work with latest nix-darwin changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ My nix config for macos
 
 These instructions should be run a fresh macos install. If you are not on a fresh macos install, these may not work for you.
 
-Install the nix using the [Determinate Systems Installer](https://github.com/DeterminateSystems/nix-installer?tab=readme-ov-file#install-nix)
+Install the nix using the [Determinate Systems Installer](https://github.com/DeterminateSystems/nix-installer?tab=readme-ov-file#install-nix), make sure to say no when the installer asks to use determinate-nix
 ```bash
 curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
-  sh -s -- install --determinate
+  sh -s -- install
 ```
 
 Open a new terminal window and use [nix env shell](https://nix.dev/manual/nix/2.25/command-ref/new-cli/nix3-env-shell) to temporary access git and clone the repo
@@ -27,9 +27,9 @@ cd to the root of the repo, open flake.nix in your editor of choice and update t
 ```bash
 # user specific variables
 system = "aarch64-darwin";
-username = "__whoami__";
+username = "whoami";
 homedir = "/Users/${username}";
-hostname = "__$echo HOST__";
+hostname = "echo $HOST";
 ```
 
 cd to home and open git.nix in your editor of choice and update the following variables

--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,26 @@
 {
   "nodes": {
+    "home-manager": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1739570999,
+        "narHash": "sha256-eCc0/Q4bPpe4/AS+uzIrHLJcR6BxPQ69q2kD0/Qe6rU=",
+        "owner": "nix-community",
+        "repo": "home-manager",
+        "rev": "254d47082e23dbf72fdeca1da6fe1da420f478d8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "ref": "release-24.11",
+        "repo": "home-manager",
+        "type": "github"
+      }
+    },
     "nix-darwin": {
       "inputs": {
         "nixpkgs": [
@@ -7,37 +28,39 @@
         ]
       },
       "locked": {
-        "lastModified": 1735685839,
-        "narHash": "sha256-62xAPSs5VRZoPH7eRanUn5S5vZEd+8vM4bD5I+zxokc=",
+        "lastModified": 1739553546,
+        "narHash": "sha256-L4ou3xfOr17EAe836djRoQ7auVkYOREMtiQa82wVGqU=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "6a1fdb2a1204c0de038847b601cff5012e162b5e",
+        "rev": "353846417f985e74fdc060555f17939e4472ea2c",
         "type": "github"
       },
       "original": {
         "owner": "LnL7",
+        "ref": "nix-darwin-24.11",
         "repo": "nix-darwin",
         "type": "github"
       }
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1735821806,
-        "narHash": "sha256-cuNapx/uQeCgeuhUhdck3JKbgpsml259sjUQnWM7zW8=",
+        "lastModified": 1739692852,
+        "narHash": "sha256-xdEEfu5F1sFL0AYpzPjpa+9vVwN1JwaomhX1VOxXy0A=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d6973081434f88088e5321f83ebafe9a1167c367",
+        "rev": "c0ac6b765343b1832e896a7ec2fed107753e710e",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixpkgs-unstable",
+        "ref": "nixpkgs-24.11-darwin",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "home-manager": "home-manager",
         "nix-darwin": "nix-darwin",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-24.11-darwin";
-    nix-darwin.url = "github:LnL7/nix-darwin";
+    nix-darwin.url = "github:LnL7/nix-darwin/nix-darwin-24.11";
     nix-darwin.inputs.nixpkgs.follows = "nixpkgs";
 
     home-manager = {


### PR DESCRIPTION
## Description

Configuration was broken with the latest nix-darwin changes that included the nix.enable setting. These changes were made while debugging configuration issues caused by an update on [2025-01-29](https://github.com/LnL7/nix-darwin/blob/678b22642abde2ee77ae2218ab41d802f010e5b0/CHANGELOG#L2). 

README
- Update installation instructions to not use determinate-nix and instead install vanilla nix as some nix-darwin features are unavailable when using the determinate daemon.
- Clean up user specific variables

flake.lock
- Update flake.lock to reflect latest changes in flake files

flake.nix
- Set the nix-darwin version to 24.11 to match nixpkgs and home manager.

Shoutout to `thurs` and `sarco` on the Nix\NixOS discord for helping me fix the issues in my configuration. 



## Checklist
- [x] Tested changes on macos VM?
