### PR TITLE
Setup ghostty config, starship and zsh improvements

### DIFF
--- a/dotfiles/ghostty/config
+++ b/dotfiles/ghostty/config
@@ -1,0 +1,7 @@
+theme = MaterialOcean
+window-decoration = false
+macos-titlebar-style = hidden
+font-family = GeistMono NFM
+shell-integration-features = no-cursor
+cursor-style = block
+cursor-style-blink = false

--- a/home/core.nix
+++ b/home/core.nix
@@ -1,4 +1,8 @@
-{pkgs, ...}: {
+{
+  pkgs,
+  config,
+  ...
+}: {
   home.packages = with pkgs; [
     cowsay
     fzf
@@ -11,6 +15,12 @@
       enable = true;
       defaultEditor = true;
       vimAlias = true;
+    };
+  };
+
+  xdg.configFile = {
+    ghostty = {
+      source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/Desktop/nix-config/dotfiles/ghostty";
     };
   };
 }

--- a/home/core.nix
+++ b/home/core.nix
@@ -18,6 +18,10 @@
     };
   };
 
+  home.file = {
+    ".hushlogin".text = "";
+  };
+
   xdg.configFile = {
     ghostty = {
       source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/Desktop/nix-config/dotfiles/ghostty";

--- a/home/starship.nix
+++ b/home/starship.nix
@@ -4,7 +4,7 @@
     enableZshIntegration = true;
     settings = {
       format = builtins.concatStringsSep "" [
-        " $username"
+        "  $username"
         "$hostname"
         "$localip"
         "$shlvl"


### PR DESCRIPTION
## Description

home/core.nix
- Creates a sym link pattern for config files that I don't want to be managed by home-manager
- Create a home.file pattern for config files that I do want to be managed by home-manager

dotfiles
- Create dotfiles directory
- Add ghostty configuration to dotfiles directory

## Checklist
- [x] Tested changes on macos VM?
