### PR TITLE
override devicons, telescope uses mini.icons

### DIFF
--- a/dotfiles/nvim/lua/config/plugins/mini.lua
+++ b/dotfiles/nvim/lua/config/plugins/mini.lua
@@ -6,6 +6,13 @@ return {
       require("mini.diff").setup()
       require("mini.git").setup()
       require("mini.icons").setup()
+
+      -- overrides devicons so that telescope uses the icons from mini.icons
+      package.preload["nvim-web-devicons"] = function()
+        require("mini.icons").mock_nvim_web_devicons()
+        return package.loaded["nvim-web-devicons"]
+      end
+
       require("mini.statusline").setup()
     end,
   },


### PR DESCRIPTION
## Description

Telescope defaults to using the [icons from nvim-tree](https://github.com/nvim-tree/nvim-web-devicons), this makes it so that it can use mini.icons the same icons used in the status line.

## Checklist
- [x] Tested changes on macos VM?
