### PR TITLE
Setup aerospace window manager

### DIFF
--- a/dotfiles/aerospace/aerospace.toml
+++ b/dotfiles/aerospace/aerospace.toml
@@ -1,0 +1,53 @@
+default-root-container-layout = 'tiles'
+on-focus-changed = "move-mouse window-force-center"
+
+enable-normalization-flatten-containers = true
+enable-normalization-opposite-orientation-for-nested-containers = true
+
+accordion-padding = 30
+
+default-root-container-orientation = 'auto'
+
+[[on-window-detected]]
+if.app-id="com.mitchellh.ghostty"
+run= [
+  "layout floating",
+]
+
+[gaps]
+    inner.horizontal = 5
+    inner.vertical =   5
+    outer.left =       5
+    outer.bottom =     5
+    outer.top =        5
+    outer.right =      5
+
+[mode.main.binding]
+    ctrl-alt-cmd-h = 'focus left'
+    ctrl-alt-cmd-j = 'focus down'
+    ctrl-alt-cmd-k = 'focus up'
+    ctrl-alt-cmd-l = 'focus right'
+
+    ctrl-alt-cmd-shift-h = 'move left'
+    ctrl-alt-cmd-shift-j = 'move down'
+    ctrl-alt-cmd-shift-k = 'move up'
+    ctrl-alt-cmd-shift-l = 'move right'
+
+    ctrl-alt-cmd-shift-left = 'resize smart +50'
+    ctrl-alt-cmd-shift-right = 'resize smart -50'
+
+    ctrl-alt-cmd-1 = 'workspace 1'
+    ctrl-alt-cmd-2 = 'workspace 2'
+    ctrl-alt-cmd-3 = 'workspace 3'
+    ctrl-alt-cmd-4 = 'workspace 4'
+    ctrl-alt-cmd-5 = 'workspace 5'
+
+    ctrl-alt-cmd-shift-1 = ['move-node-to-workspace 1', 'workspace 1']
+    ctrl-alt-cmd-shift-2 = ['move-node-to-workspace 2', 'workspace 2']
+    ctrl-alt-cmd-shift-3 = ['move-node-to-workspace 3', 'workspace 3']
+    ctrl-alt-cmd-shift-4 = ['move-node-to-workspace 4', 'workspace 4']
+    ctrl-alt-cmd-shift-5 = ['move-node-to-workspace 5', 'workspace 5']
+
+    ctrl-alt-cmd-t = 'layout tiles horizontal vertical'
+
+    ctrl-alt-cmd-f = ['layout floating tiling', 'mode main']

--- a/home/core.nix
+++ b/home/core.nix
@@ -54,5 +54,8 @@
     nvim = {
       source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/Dev/nix-config/dotfiles/nvim";
     };
+    aerospace = {
+      source = config.lib.file.mkOutOfStoreSymlink "${config.home.homeDirectory}/Dev/nix-config/dotfiles/aerospace";
+    };
   };
 }

--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -8,6 +8,7 @@
       "arc"
       "obsidian"
       "font-geist-mono-nerd-font"
+      "nikitabobko/tap/aerospace"
     ];
 
     onActivation.cleanup = "zap";


### PR DESCRIPTION
## Description

dotfiles/aerospace/aerospace.toml
- init aerospace configuration
- includes special configuration so ghostty with native tabs works

home/core.nix
- sym link the aerospace configuration with the .config directory

modules/homebrew.nix
- add aerospace to homebrew cask lists

## Checklist
- [x] Tested changes?
