### PR TITLE
Update LSP keybinds

### DIFF
--- a/dotfiles/nvim/lua/config/core/keymaps.lua
+++ b/dotfiles/nvim/lua/config/core/keymaps.lua
@@ -23,11 +23,13 @@ keymap.set("n", "<leader>ec", function() -- list files in ~/Desktop/nix-config d
   })
 end)
 
--- Lsp
 vim.api.nvim_create_autocmd("LspAttach", {
   callback = function()
-    vim.keymap.set("n", "gd", vim.lsp.buf.definition, { buffer = 0 })
-    vim.keymap.set("n", "gr", vim.lsp.buf.definition, { buffer = 0 })
-    vim.keymap.set("n", "K", vim.lsp.buf.definition, { buffer = 0 })
+    keymap.set("n", "grn", vim.lsp.buf.rename)
+    keymap.set({ "n", "v" }, "gra", vim.lsp.buf.code_action)
+    keymap.set("n", "grr", vim.lsp.buf.references)
+    keymap.set("n", "gri", vim.lsp.buf.implementation)
+    keymap.set("n", "gO", vim.lsp.buf.document_symbol)
+    keymap.set("i", "<C-s>", vim.lsp.buf.signature_help)
   end,
 })

--- a/flake.lock
+++ b/flake.lock
@@ -7,11 +7,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1742234739,
-        "narHash": "sha256-zFL6zsf/5OztR1NSNQF33dvS1fL/BzVUjabZq4qrtY4=",
+        "lastModified": 1744117652,
+        "narHash": "sha256-t7dFCDl4vIOOUMhEZnJF15aAzkpaup9x4ZRGToDFYWI=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "f6af7280a3390e65c2ad8fd059cdc303426cbd59",
+        "rev": "b4e98224ad1336751a2ac7493967a4c9f6d9cb3f",
         "type": "github"
       },
       "original": {
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741126078,
-        "narHash": "sha256-ng0a4cIq3c9E3iGKomlwqKzVYs2RLOzQho2U1Mc2sqU=",
+        "lastModified": 1743127615,
+        "narHash": "sha256-+sMGqywrSr50BGMLMeY789mSrzjkoxZiu61eWjYS/8o=",
         "owner": "LnL7",
         "repo": "nix-darwin",
-        "rev": "c172f50b55b087f8e7801631de977461603bb976",
+        "rev": "fc843893cecc1838a59713ee3e50e9e7edc6207c",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1742305402,
-        "narHash": "sha256-56UcjoVVkB7rAbiY9Y79Th4pOlx0e1hv6Cfny8rlP8U=",
+        "lastModified": 1744014960,
+        "narHash": "sha256-fzXKqdVy21k6blyasPZFfWTbFExqhjsHqaX6Fs7Ie4M=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6c8e4e4546146ddf05e9433ca560fa6260d00a14",
+        "rev": "5ab30477b63c34d2c1e909e464a96b13fa73da0b",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Description

dotfiles/nvim/lua/config/core/keymaps.lua
- Update lsp keybinds based on neovim [docs](https://neovim.io/doc/user/lsp.html). These are set by default in neovim 0.11.0 but since 0.10.2 is the latest version on nixpkgs 24.11 setting them manually.

## Checklist
- [x] Tested changes?
