### PR TITLE
Remove supermaven

### DIFF
--- a/dotfiles/nvim/lua/config/plugins/supermaven.lua
+++ b/dotfiles/nvim/lua/config/plugins/supermaven.lua
@@ -1,8 +1,0 @@
-return {
-  {
-    "supermaven-inc/supermaven-nvim",
-    config = function()
-      require("supermaven-nvim").setup({})
-    end,
-  },
-}


### PR DESCRIPTION
## Description

Getting rid of supermaven as it isn't as good as I expected. Still better than copilot but not as good as cursor tab seems. I feel myself getting more and more reliant on AI so trying to get away from that.

dotfiles/nvim/lua/config/plugins/supermaven.lua
- delete

## Checklist
- [x] Tested changes?
