### PR TITLE
Roslyn fixes

### DIFF
--- a/dotfiles/nvim/lua/config/plugins/lsp.lua
+++ b/dotfiles/nvim/lua/config/plugins/lsp.lua
@@ -4,6 +4,39 @@ return {
   {
     "seblyng/roslyn.nvim",
     ft = "cs",
+    opts = {
+      filewatching = "roslyn",
+      config = {
+        settings = {
+          ["csharp|background_analysis"] = {
+            dotnet_compiler_diagnostics_scope = "fullSolution",
+          },
+          ["csharp|inlay_hints"] = {
+            csharp_enable_inlay_hints_for_implicit_object_creation = true,
+            csharp_enable_inlay_hints_for_implicit_variable_types = true,
+            csharp_enable_inlay_hints_for_lambda_parameter_types = true,
+            csharp_enable_inlay_hints_for_types = true,
+            dotnet_enable_inlay_hints_for_indexer_parameters = true,
+            dotnet_enable_inlay_hints_for_literal_parameters = true,
+            dotnet_enable_inlay_hints_for_object_creation_parameters = true,
+            dotnet_enable_inlay_hints_for_other_parameters = true,
+            dotnet_enable_inlay_hints_for_parameters = true,
+            dotnet_suppress_inlay_hints_for_parameters_that_differ_only_by_suffix = true,
+            dotnet_suppress_inlay_hints_for_parameters_that_match_argument_name = true,
+            dotnet_suppress_inlay_hints_for_parameters_that_match_method_intent = true,
+          },
+          ["csharp|code_lens"] = {
+            dotnet_enable_references_code_lens = true,
+          },
+          ["csharp|completion"] = {
+            dotnet_show_completion_items_from_unimported_namespaces = true,
+          },
+          ["csharp|formating"] = {
+            dotnet_organize_imports_on_format = true,
+          },
+        },
+      },
+    },
   },
   {
     "neovim/nvim-lspconfig",

--- a/users/aashishsharmawork.nix
+++ b/users/aashishsharmawork.nix
@@ -21,7 +21,12 @@
     docker
     colima
     lazydocker
-    dotnet-sdk_8
+    # Work project is dotnet 8, roslyn lsp is dotnet 9
+    (with dotnetCorePackages;
+      combinePackages [
+        sdk_8_0
+        sdk_9_0
+      ])
     azurite
     azure-cli
     pnpm


### PR DESCRIPTION
## Description

Fixes issues with roslyn lsp by installing dotnet 8 and 9 on work machine.

dotfiles/nvim/lua/config/plugins/lsp.lua
- Update roslyn configuration

users/aashishsharmawork.nix
- Use both dotnet 8 and 9

## Checklist
- [x] Tested changes?
