### PR TITLE
Remove expand tab, add modern csv

### DIFF
--- a/dotfiles/nvim/lua/config/core/options.lua
+++ b/dotfiles/nvim/lua/config/core/options.lua
@@ -8,7 +8,6 @@ opt.relativenumber = true
 opt.tabstop = 4
 opt.softtabstop = 4
 opt.shiftwidth = 4
-opt.expandtab = true
 
 -- line wrapping
 opt.linebreak = true

--- a/hosts/aashishs-work-macbook-pro.nix
+++ b/hosts/aashishs-work-macbook-pro.nix
@@ -34,6 +34,7 @@
       "rider"
       "google-chrome"
       "microsoft-azure-storage-explorer"
+      "modern-csv"
     ];
   };
 }


### PR DESCRIPTION
## Description

dotfiles/nvim/lua/config/core/options.lua
- Removes expand tab, which inserts spaces when using tab

hosts/aashishs-work-macbook-pro.nix
- adds modern csv to work casks



## Checklist
- [x] Tested changes?
