### PR TITLE
Fix mullvadvpn cask

### DIFF
--- a/hosts/aashishs-macbook-pro.nix
+++ b/hosts/aashishs-macbook-pro.nix
@@ -30,7 +30,7 @@
       "legcord"
       "utm"
       "anki"
-      "mullvadvpn"
+      "mullvad-vpn"
     ];
   };
 }


### PR DESCRIPTION
## Description

Every time I did a darwin rebuild mullvad was reinstalling, this was due to the cask name incorrect. This was introduced in #82.

hosts/aashishs-macbook-pro.nix
- Fix mullvad-vpn cask

## Checklist
- [x] Tested changes?
