### PR TITLE
Remove unnecessary home manager configurations

### DIFF
--- a/home/core.nix
+++ b/home/core.nix
@@ -5,11 +5,7 @@
   homedir,
   ...
 }: {
-  home = {
-    username = username;
-    homeDirectory = homedir;
-    stateVersion = "25.05";
-  };
+  home.stateVersion = "25.05";
 
   programs.home-manager.enable = true;
 


### PR DESCRIPTION
## Description

Learned recently that you shouldn't set home.username and home.homeDirectory as nix-darwin will do it.

home/core.nix
- remove home.username
- remove home.homeDirectory

## Checklist
- [x] Tested changes?
