### PR TITLE
Set auto show completion to false

### DIFF
--- a/dotfiles/nvim/lua/config/plugins/lsp.lua
+++ b/dotfiles/nvim/lua/config/plugins/lsp.lua
@@ -63,6 +63,12 @@ return {
 						use_nvim_cmp_as_default = true,
 						nerd_font_variant = "mono",
 					},
+
+					completion = {
+						menu = {
+						  auto_show = false
+						},
+					},
 				},
 			},
 		},


### PR DESCRIPTION
## Description

Inspired by this [article](https://kennethnym.com/blog/autocomplete-considered-harmful/) on autocomplete considered harmful by kennethnym I have decided to disable completion menu to show up automatically. It can still be accessed via C-space.

dotfiles/nvim/lua/config/plugins/lsp.lua
- blink.cmp auto_show completion set to false

## Checklist
- [x] Tested changes?
