### PR TITLE
Set git blame.ignoreRevsFile, remove arc

### DIFF
--- a/home/git.nix
+++ b/home/git.nix
@@ -12,6 +12,7 @@
       tag.gpgSign = true;
       gpg.format = "ssh";
       user.signingKey = "~/.ssh/id_ed25519.pub";
+      blame.ignoreRevsFile = ".git-blame-ignore-revs";
     };
 
     delta = {

--- a/hosts/aashishs-macbook-pro.nix
+++ b/hosts/aashishs-macbook-pro.nix
@@ -17,7 +17,7 @@
     defaults = {
       dock = {
         persistent-apps = [
-          "/Applications/Arc.app"
+          "/Applications/Helium.app"
           "/Applications/Ghostty.app"
           "/Applications/Obsidian.app"
         ];

--- a/hosts/aashishs-work-macbook-pro.nix
+++ b/hosts/aashishs-work-macbook-pro.nix
@@ -17,7 +17,7 @@
     defaults = {
       dock = {
         persistent-apps = [
-          "/Applications/Arc.app"
+          "/Applications/Helium.app"
           "/Applications/Ghostty.app"
           "/Applications/DataGrip.app"
           "/Applications/Obsidian.app"

--- a/modules/homebrew.nix
+++ b/modules/homebrew.nix
@@ -5,7 +5,6 @@
     casks = [
       "raycast"
       "ghostty"
-      "arc"
       "obsidian"
       "font-geist-mono-nerd-font"
       "aerospace"


### PR DESCRIPTION
## Description

home/git.nix
- Add configuration to use .git-blame-ignore-revs if available

hosts/aashishs-macbook-pro.nix
- replace arc with helium on personal dock

hosts/aashishs-work-macbook-pro.nix
- replace arc with helium on work dock

modules/homebrew.nix
- remove arc brew cask

## Checklist
- [x] Tested changes?
