### PR TITLE
Update starship nix-shell configuration

### DIFF
--- a/home/starship.nix
+++ b/home/starship.nix
@@ -173,7 +173,9 @@
       };
 
       nix_shell = {
-        symbol = " ";
+        symbol = "";
+        impure_msg = "";
+        heuristic = true;
       };
 
       os = {


### PR DESCRIPTION
## Description

Starship always shows impure when in a nix shell, and spacing on the logo is messed up.

home/starship.nix
- Update symbol spacing
- disable impure_msg
- enable heuristic

## Checklist
- [x] Tested changes?
