### PR TITLE
Setup autocompletion keybind

### DIFF
--- a/dotfiles/nvim/lua/config/core/keymaps.lua
+++ b/dotfiles/nvim/lua/config/core/keymaps.lua
@@ -65,3 +65,13 @@ end
 keymap.set("n", "<leader>d", Toggle_diagnostics)
 
 keymap.set("n", "<leader>n", "<cmd>Oil<cr>")
+
+keymap.set("n", "<leader>ac", function()
+	if vim.b.completion == true or vim.b.completion == nil then
+		vim.b.completion = false
+		vim.notify("Auto Completion Disabled")
+	else
+		vim.b.completion = true
+		vim.notify("Auto Completion Enabled")
+	end
+end)

--- a/dotfiles/nvim/lua/config/plugins/lsp.lua
+++ b/dotfiles/nvim/lua/config/plugins/lsp.lua
@@ -63,12 +63,6 @@ return {
 						use_nvim_cmp_as_default = true,
 						nerd_font_variant = "mono",
 					},
-
-					completion = {
-						menu = {
-						  auto_show = false
-						},
-					},
 				},
 			},
 		},


### PR DESCRIPTION
## Description

dotfiles/nvim/lua/config/core/keymaps.lua
- leader+ac now toggles auto completion, with auto completion enabled by default

dotfiles/nvim/lua/config/plugins/lsp.lua
- completion menu auto show back to default of true

## Checklist
- [x] Tested changes?
