### PR TITLE
Set aerospace gaps to 0

### DIFF
--- a/dotfiles/aerospace/aerospace.toml
+++ b/dotfiles/aerospace/aerospace.toml
@@ -36,12 +36,12 @@ if.app-id="us.zoom.xos"
 run = "move-node-to-workspace 3"
 
 [gaps]
-    inner.horizontal = 5
-    inner.vertical =   5
-    outer.left =       5
-    outer.bottom =     5
-    outer.top =        5
-    outer.right =      5
+    inner.horizontal = 0
+    inner.vertical =   0
+    outer.left =       0
+    outer.bottom =     0
+    outer.top =        0
+    outer.right =      0
 
 [mode.main.binding]
     ctrl-alt-cmd-h = 'focus left'


### PR DESCRIPTION
## Description

Any bright wallpaper is distracting with gaps. Having no gaps give me more options for wallpapers.

dotfiles/aerospace/aerospace.toml
- Set gaps to 0

## Checklist
- [x] Tested changes?
