### PR TITLE
chromium disable widevine

### DIFF
--- a/modules/common/home-manager.nix
+++ b/modules/common/home-manager.nix
@@ -51,7 +51,7 @@
           }))
         ]
         ++ lib.optionals pkgs.stdenv.isLinux [
-          (pkgs.ungoogled-chromium.override {enableWideVine = true;})
+          pkgs.ungoogled-chromium
           pkgs.git
           pkgs.ddcutil
           pkgs.btop


### PR DESCRIPTION
## Description

Disables widevine overrride for chormium. This change will make it so that DRM protected content such as Netflix will not work on my mixos system.

## Checklist
- [x] Tested changes?
